### PR TITLE
Remove default value for factories option arguments

### DIFF
--- a/test/deriver/pp_factory.expected
+++ b/test/deriver/pp_factory.expected
@@ -19,3 +19,10 @@ let factory_simple_variant_b ?(tup0= 0)  () = B tup0
 let factory_simple_variant_c ?(tup0= 0)  ?(tup1= "")  () = C (tup0, tup1)
 let factory_simple_variant_d ?(int_field= 0)  ?(string_field= "")  () =
   D { int_field; string_field }
+type record_with_options =
+  {
+  non_optional: int ;
+  optional: int option ;
+  nested: int option option }[@@deriving factory]
+let factory_record_with_options ?(non_optional= 0)  ?optional  ?nested  () =
+  { non_optional; optional; nested }

--- a/test/deriver/test_factory.ml
+++ b/test/deriver/test_factory.ml
@@ -18,3 +18,10 @@ type simple_variant =
   | C of int * string
   | D of {int_field : int; string_field : string}
 [@@deriving factory]
+
+type record_with_options =
+  { non_optional : int
+  ; optional : int option
+  ; nested : int option option
+  }
+[@@deriving factory]


### PR DESCRIPTION
The following code:
```ocaml
type t =
  { some_int: int
  ; some_option: float option
  }
[@@deriving factory]
```
used to derive the following function:
```ocaml
let factory ?(some_int=0) ?(some_option=None) () = {some_int; some_option}
```
While this works I tend to find it convenient to be able to pass values directly to labelled arguments instead of manually having to wrap them in a `(Some (...))`.
That's why now it generates the following function instead:
```ocaml
let factory ?(some_int=0) ?some_option () = {some_int; some_option}
```
It's important to note that you can still explicitly pass `None` by writing:
```ocaml
let some_t = factory ?some_option:None ()
```