### PR TITLE
Raise when deriving a factory from an actual abstract type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## unreleased
+
+### Fixes
+
+- Raise an error when used with an abstract type, except when invoked from `ocamldep`, @NathanReb
+  [#20](https://github.com/cryptosense/ppx_factory/pull/20)
+
 ## v0.0.0
 
 *2019-03-07*

--- a/README.md
+++ b/README.md
@@ -198,20 +198,3 @@ On the other hand it can derive a default value that as type `('a, 'b) t2` such 
 It is worth noting that **you should never rely on what the actual value of such a default is** as
 it is susceptible to change in minor or even patch releases. If your tests depend on a default value
 it means you're not using factories right!
-
-## Known issues
-
-### Silent failure on abstract types
-
-If you try to derive factory functions from an abstract type, like in the following example:
-```ocaml
-type t1
-[@@deriving factory]
-
-type t2 = Some_external_module.t
-[@@deriving factory]
-```
-
-it will silently produce nothing. This is due to a current limitation in `ppxlib` combined with a
-necessity to be compatible with `ppx_import`. We're working on fixing that and hope to be able to
-provide users with an approriate error message in those cases instead.

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -14,6 +14,11 @@ let core_type_from_type_decl ~loc {ptype_name; ptype_params; _} =
   let type_lident = {txt = Lident ptype_name.txt; loc} in
   Ast_builder.Default.ptyp_constr ~loc type_lident constr
 
+let is_ocamldep ctxt =
+  let omp_config = Expansion_context.Deriver.omp_config ctxt in
+  let tool_name = omp_config.Migrate_parsetree.Driver.tool_name in
+  String.equal tool_name "ocamldep"
+
 module Expr = struct
   let var ~loc var_name = Ast_builder.Default.pexp_ident ~loc {txt = Lident var_name; loc}
   let constructor ~loc ~constructor_name expr =

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -8,6 +8,11 @@ val affix_from_type_name : kind: [`Prefix | `Suffix] -> string -> string
 *)
 val core_type_from_type_decl : loc: Location.t -> type_declaration -> core_type
 
+(** Return whether the deriver is used in the context of ocamldep from the given
+    expansion context
+*)
+val is_ocamldep : Expansion_context.Deriver.t -> bool
+
 module Expr : sig
   (** Return the expression corresponding to the given variable name *)
   val var : loc: Location.t -> string -> expression

--- a/ppx_factory.opam
+++ b/ppx_factory.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {build}
   "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.3.0"}
+  "ppxlib" {>= "0.6.0"}
   "ppx_deriving" {with-test}
 ]
 tags: ["org:cryptosense"]

--- a/test/deriver/errors/dune.inc
+++ b/test/deriver/errors/dune.inc
@@ -42,3 +42,25 @@
   (name runtest)
   (action (diff default_str_unspecified_type.expected default_str_unspecified_type.actual))
 )
+
+(library
+  (name factory_abstract_type)
+  (modules factory_abstract_type)
+  (preprocess (pps ppx_factory))
+)
+
+(rule
+  (targets factory_abstract_type.actual)
+  (deps (:pp pp.exe) (:input factory_abstract_type.ml))
+  (action
+    (with-stderr-to
+      %{targets}
+      (bash "./%{pp} -no-color --impl %{input} || true")
+    )
+  )
+)
+
+(alias
+  (name runtest)
+  (action (diff factory_abstract_type.expected factory_abstract_type.actual))
+)

--- a/test/deriver/errors/factory_abstract_type.expected
+++ b/test/deriver/errors/factory_abstract_type.expected
@@ -1,0 +1,2 @@
+File "factory_abstract_type.ml", line 1, characters 0-33:
+Error: ppx_factory.factory: cannot derive from abstract type. Has to be a record or variant type.

--- a/test/deriver/errors/factory_abstract_type.ml
+++ b/test/deriver/errors/factory_abstract_type.ml
@@ -1,0 +1,2 @@
+type t = int
+[@@deriving factory]


### PR DESCRIPTION
Fixes #14

Ppxlib 0.6.0 makes it possible to get the tool name from deriver and extensions code. This PR reintroduce the error when `[@@deriving factory]` is used on an abstract while maintaining compatibility with `ppx_import`.

You might not want to merge this right away as ppxlib 0.6.0 unfortunately conflicts with quite a few janestreet packages so it is likely to break Cryptosense's dependencies!