### PR TITLE
Make ppx_factory compatible with ppxlib.0.14.0

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -15,8 +15,7 @@ let core_type_from_type_decl ~loc {ptype_name; ptype_params; _} =
   Ast_builder.Default.ptyp_constr ~loc type_lident constr
 
 let is_ocamldep ctxt =
-  let omp_config = Expansion_context.Deriver.omp_config ctxt in
-  let tool_name = omp_config.Migrate_parsetree.Driver.tool_name in
+  let tool_name = Expansion_context.Deriver.tool_name ctxt in
   String.equal tool_name "ocamldep"
 
 module Expr = struct

--- a/ppx_factory.opam
+++ b/ppx_factory.opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.1"}
   "ocaml" {>= "4.07.0" & < "4.11.0"}
   "ounit" {with-test & >= "2.0.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.14.0"}
   "ppx_deriving" {with-test}
 ]
 tags: ["org:cryptosense"]


### PR DESCRIPTION
Ahead of some major changes in OMP, the next release of ppxlib will, in addition to bumping the internal AST to 4.10, break part of its API so it doesn't leak OMP's config anymore.

This PR patches ppx_factory so that it's compatible with the soon to-be-released ppxlib.

We'll take care of adding the proper upper bounds to the released versions of ppx_factory when releasing ppxlib.

You'll probably want to wait for the release before merging but at least the job's done.